### PR TITLE
bin/mpath: fix shebang

### DIFF
--- a/bin/mpath
+++ b/bin/mpath
@@ -1,4 +1,4 @@
-#!/usr/bin/env perl
+#!perl
 use strict;
 use warnings;
 use 5.006;


### PR DESCRIPTION
`#!/usr/bin/env perl` => `#!perl`

Because ExtUtils::MakeMaker will replace `#!perl` with the real `perl` location during install. This allow to avoid cases where the `mpath` script will run with a perl that is not the one where the Module::Path modules are installed.