### PR TITLE
Extend Perls tested in Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ script: prove -lr t
 install:
   - cpanm -n -q --skip-satisfied --installdeps .
 perl:
+  - "5.22"
+  - "5.20"
   - "5.18"
   - "5.16"
   - "5.14"


### PR DESCRIPTION
At present, Travis has Perl versions 5.10 .. 5.22 available.  Add Perls 5.20
and 5.22 to the list of versions to test.

Of course, it would be nice to test 5.24 as well, however I've not yet got around to asking the Travis people to add 5.24 to their list of available perls...