### PR TITLE
Remove trailing whitespace in docs

### DIFF
--- a/lib/Module/Path.pm
+++ b/lib/Module/Path.pm
@@ -68,7 +68,7 @@ Module::Path - get the full path to a locally installed module
 =head1 SYNOPSIS
 
  use Module::Path 'module_path';
- 
+
  $path = module_path('Test::More');
  if (defined($path)) {
    print "Test::More found at $path\n";


### PR DESCRIPTION
Sometimes people like trailing whitespace to be removed, sometimes people don't.  Here's a very small patch removing unnecessary whitespace from the project.  You can merge this if you want, but I won't be offended if you don't :-)