### PR TITLE
Update copyright year to current release year

### DIFF
--- a/bin/mpath
+++ b/bin/mpath
@@ -104,7 +104,7 @@ Neil Bowers E<lt>neilb@cpan.orgE<gt>
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2012 by Neil Bowers E<lt>neilb@cpan.orgE<gt>.
+This software is copyright (c) 2015 by Neil Bowers E<lt>neilb@cpan.orgE<gt>.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.

--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = Module-Path
 author  = Neil Bowers <neilb@cpan.org>
 license = Perl_5
 copyright_holder = Neil Bowers
-copyright_year   = 2013
+copyright_year   = 2015
 
 version = 0.19
 

--- a/lib/Module/Path.pm
+++ b/lib/Module/Path.pm
@@ -191,7 +191,7 @@ Neil Bowers E<lt>neilb@cpan.orgE<gt>
 
 =head1 COPYRIGHT AND LICENSE
 
-This software is copyright (c) 2012 by Neil Bowers <neilb@cpan.org>.
+This software is copyright (c) 2015 by Neil Bowers <neilb@cpan.org>.
 
 This is free software; you can redistribute it and/or modify it under
 the same terms as the Perl 5 programming language system itself.


### PR DESCRIPTION
This commit also makes the copyright years internally consistent: there was
a different copyright year mentioned in the `dist.ini` to that mentioned in
the code.