### PR TITLE
Remove explicit undef in return statement

### DIFF
--- a/lib/Module/Path.pm
+++ b/lib/Module/Path.pm
@@ -56,7 +56,7 @@ sub module_path
         return $fullpath if -f $fullpath;
     }
 
-    return undef;
+    return;
 }
 
 1;


### PR DESCRIPTION
According to Perl Best Practices, using an explicit `undef` to return
failure doesn't always work as one intended (e.g. in list context a single
elemnt list containing `(undef)` is returned which is true in boolean
context, and hence not what one wants.  Removing the `undef` fixes the
`perlcritic` violation, keeps the tests passing and seems to maintain the
desired behaviour.

If you have any questions or comments concerning this patch, please don't hesitate to contact me!  It is intended to be helpful, and if I can improve it, just let me know and I'll update the patch and resubmit.