### PR TITLE
Ignore files and dirs auto-generated by dzil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.build
+Module-Path-*


### PR DESCRIPTION
This PR just adds a simple `.gitignore` file ignoring the artifacts automatically generated by `Dist::Zilla` and which can be ignored in the output of e.g. `git status`.